### PR TITLE
Make udl_server.py interactive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 asciimatics
+prompt_toolkit

--- a/trace2op.py
+++ b/trace2op.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 import array
 import json
+from collections.abc import Iterable
 
 from pialarm import SerialWintex, MemStore, WintexMemDecoder
 
@@ -126,7 +127,10 @@ class MemStore():
 	def __setitem__(self, key, value):
 		#if key > self.size:
 		#	raise IndexError('position {:x} is beyond size={:x}'.format(key, self.size))
-		self.backing_array[key:key+len(value)] = array.array('B', value)
+		if isinstance(value, Iterable):
+			self.backing_array[key:key+len(value)] = array.array('B', value)
+		else:
+			self.backing_array[key] = value
 
 
 class WintexMemDecoder():

--- a/udl-server.py
+++ b/udl-server.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import trio
 from itertools import count
@@ -5,6 +7,7 @@ from pialarm import SerialWintex, MemStore
 from functools import partial
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("--panel", help="Specify the panel to identify as", default='Elite 24    V4.02.01')
 parser.add_argument("--verbose", help="Print instructions", action='store_true', default=False)
 parser.add_argument("--debug", help="Print bytes on wire", action='store_true', default=False)
 parser.add_argument("--mem", help="write observed values to MEMFILE in position")
@@ -42,7 +45,10 @@ class SerialWintexPanel(SerialWintex):
             return self.prep('Z\x05\x01\x00\x07\x09\x04\x07\x01')
         elif mtype == 'Z':
             print('Sending panel identification')
-            return self.prep('ZElite 24    V4.02.01')
+            return self.prep('Z' + self.args.panel)
+        elif mtype == 'H':
+            print('Wintex hang up')
+            return [ 0x03, 0x06, 0xF6 ]
         # wintex shows 'Reading UDL options'
         elif mtype == 'O': # configuration read
             base, sz, wr_data, old_data = unpack_mem_proto(self.mem, body)


### PR DESCRIPTION
And support other panels.

These changes make udl_server.py interactive, allowing dynamic change of memory regions, both configuration and dynamic. This makes use of prompt toolkit, which allows the prompt to be interactive, similar to GNU readline (history, etc).

The instructions captured at the prompt are "exec"d, allowing reference to the `mem` and `io` objects, which have been slightly enhanced to allow modification of single address values, not just in a list. e.g.

```
io[0x4f8] ^= (1<<0) # toggle bit 0 at address 0x4f8
io[0x4f8] = 32 * (0,) # set 32 bytes starting at address 0x4f8 to zero
```